### PR TITLE
Add link to grpc-errors repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [Flatbuffer support for gRPC C++](https://github.com/google/flatbuffers/tree/master/grpc)
 - [Go Kit with gRPC as transport](https://github.com/go-kit/kit/tree/master/transport/grpc)
 - [grpc-java-contrib](https://github.com/salesforce/grpc-java-contrib)
+- [grpc-errors](https://github.com/avinassh/grpc-errors)
 
 # Issues where we would like help from the community
 - [gRPC core](https://github.com/grpc/grpc/labels/help%20wanted)


### PR DESCRIPTION
Add link to https://github.com/avinassh/grpc-errors under "Known useful contributions around github" section.